### PR TITLE
Workaround for OutOfMemoryError : resize image. #1.

### DIFF
--- a/app/src/main/java/org/mixitconf/service/Utils.kt
+++ b/app/src/main/java/org/mixitconf/service/Utils.kt
@@ -41,6 +41,7 @@ fun ImageView.setSpeakerImage(speaker: User) {
 
     Picasso.get()
             .load(if (imageResource > 0) imageResource else R.drawable.mxt_icon_unknown)
+            .resize(160, 160)
             .into(this)
 }
 


### PR DESCRIPTION
The best correction would however to change all images to real optimized JPEG.