### PR TITLE
Typo corrections and refactoring for more idiomatic code.

### DIFF
--- a/app/src/main/java/org/mixitconf/adapter/TalkListAdapter.kt
+++ b/app/src/main/java/org/mixitconf/adapter/TalkListAdapter.kt
@@ -35,87 +35,12 @@ class TalkListAdapter(private val items: List<Talk>, val context: Context) : Rec
         val infoLayout:LinearLayout = view.findViewById(R.id.talkItemTimeContainer)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TalkListAdapter.ViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.fragment_talk_item, parent, false)
-        return ViewHolder(view)
-    }
+    override fun getItemCount(): Int = items.size
 
-    @TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val talk = items[position]
-
-        holder.name.text = talk.title
-        holder.time.text = talk.getTimeLabel(context)
-
-        when (talk.format) {
-            TALK, WORKSHOP, KEYNOTE -> {
-                paintItemView(holder, talk.getBgColorDependingOnTime(android.R.color.white))
-                displayFields(holder)
-
-                holder.talkLanguage.visibility = if (talk.language == Language.ENGLISH) View.VISIBLE else View.GONE
-                holder.image.setImageResource(talk.getTopicDrawableResource())
-                holder.type.text = talk.format.name
-                holder.description.text = talk.summary
-                holder.room.setText(talk.getRoomLabel(context))
-                holder.itemView.setOnClickListener({ _ -> (context as TalkFragment.OnTalkSelectedListener).onTalkSelected(talk.id) })
-            }
-            DAY -> {
-                paintItemView(holder, talk.getBgColorDependingOnTime(R.color.colorPrimary), nameColor = android.R.color.white)
-                holder.name.textAlignment = View.TEXT_ALIGNMENT_CENTER
-                hideFields(holder, hideTime = true)
-            }
-            RANDOM, PARTY -> {
-                paintItemView(holder, talk.getBgColorDependingOnTime(R.color.colorAccent), timeColor = android.R.color.white)
-                hideFields(holder, hideImage = false)
-            }
-            SESSION_INTRO, LUNCH, ORGA -> {
-                paintItemView(holder, talk.getBgColorDependingOnTime(R.color.colorShadow))
-                hideFields(holder, hideImage = false)
-            }
-            PAUSE_10_MIN, PAUSE_20_MIN, PAUSE_30_MIN -> {
-                paintItemView(holder, talk.getBgColorDependingOnTime(R.color.colorShadow))
-                hideFields(holder, hideImage = false)
-            }
-        }
-
-    }
-
-    private fun paintItemView(holder: ViewHolder,
-                              background: Int,
-                              nameColor: Int = android.R.color.black,
-                              timeColor: Int = R.color.textShadow) {
-        holder.itemView.setBackgroundColor(context.getColorLegacy(background))
-        holder.name.setTextColor(context.getColorLegacy(nameColor))
-        holder.time.setTextColor(context.getColorLegacy(timeColor))
-        holder.name.textAlignment = View.TEXT_ALIGNMENT_INHERIT
-    }
-
-    private fun hideFields(holder: ViewHolder, hideName: Boolean = false, hideTime: Boolean = false, hideImage: Boolean = true) {
-        holder.type.visibility = View.GONE
-        holder.description.visibility = View.GONE
-        holder.room.visibility = View.GONE
-        holder.talkLanguage.visibility = View.GONE
-        holder.name.visibility = if (hideName) View.GONE else View.VISIBLE
-        holder.infoLayout.visibility = if (hideTime) View.GONE else View.VISIBLE
-        holder.time.visibility = if (hideTime) View.GONE else View.VISIBLE
-        holder.itemView.setOnClickListener(null)
-        if (hideImage) {
-            holder.image.visibility = View.GONE
-        } else {
-            holder.image.visibility = View.VISIBLE
-            holder.image.setImageResource(R.drawable.mxt_topic_empty)
-        }
-    }
-
-    private fun displayFields(holder: ViewHolder) {
-        holder.description.visibility = View.VISIBLE
-        holder.room.visibility = View.VISIBLE
-        holder.image.visibility = View.VISIBLE
-        holder.type.visibility = View.VISIBLE
-        holder.name.visibility = View.VISIBLE
-        holder.time.visibility = View.VISIBLE
-        holder.infoLayout.visibility = View.VISIBLE
-    }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TalkListAdapter.ViewHolder =
+            ViewHolder(LayoutInflater
+                    .from(parent.context)
+                    .inflate(R.layout.fragment_talk_item, parent, false))
 
     override fun onViewRecycled(holder: TalkListAdapter.ViewHolder?) {
         super.onViewRecycled(holder)
@@ -126,8 +51,90 @@ class TalkListAdapter(private val items: List<Talk>, val context: Context) : Rec
 
     }
 
+    @TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val talk = items[position]
 
-    override fun getItemCount(): Int {
-        return items.size
+        holder.apply {
+            name.text = talk.title
+            time.text = talk.getTimeLabel(context)
+
+            when (talk.format) {
+                TALK, WORKSHOP, KEYNOTE -> {
+                    paintItemView(talk.getBgColorDependingOnTime(android.R.color.white))
+                    displayFields()
+                    talkLanguage.visibility = if (talk.language == Language.ENGLISH) View.VISIBLE else View.GONE
+                    image.setImageResource(talk.getTopicDrawableResource())
+                    type.text = talk.format.name
+                    description.text = talk.summary
+                    room.setText(talk.getRoomLabel(context))
+                    itemView.setOnClickListener({ _ -> (context as TalkFragment.OnTalkSelectedListener).onTalkSelected(talk.id) })
+
+                }
+                DAY -> {
+                    paintItemView(
+                            talk.getBgColorDependingOnTime(R.color.colorPrimary),
+                            nameColor = android.R.color.white)
+                    name.textAlignment = View.TEXT_ALIGNMENT_CENTER
+                    hideFields(hideTime = true)
+                }
+                RANDOM, PARTY -> {
+                    paintItemView(talk.getBgColorDependingOnTime(R.color.colorAccent), timeColor = android.R.color.white)
+                    holder.hideFields(hideImage = false)
+                }
+                SESSION_INTRO, LUNCH, ORGA -> {
+                    paintItemView(talk.getBgColorDependingOnTime(R.color.colorShadow))
+                    holder.hideFields(hideImage = false)
+                }
+                PAUSE_10_MIN, PAUSE_20_MIN, PAUSE_30_MIN -> {
+                    paintItemView(talk.getBgColorDependingOnTime(R.color.colorShadow))
+                    holder.hideFields(hideImage = false)
+                }
+            }
+
+        }
+
     }
+
+    private fun ViewHolder.paintItemView(
+                              background: Int,
+                              nameColor: Int = android.R.color.black,
+                              timeColor: Int = R.color.textShadow) {
+        itemView.setBackgroundColor(context.getColorLegacy(background))
+        name.setTextColor(context.getColorLegacy(nameColor))
+        time.setTextColor(context.getColorLegacy(timeColor))
+        name.textAlignment = View.TEXT_ALIGNMENT_INHERIT
+    }
+
+    private fun ViewHolder.displayFields() {
+        description.visibility = View.VISIBLE
+        room.visibility = View.VISIBLE
+        image.visibility = View.VISIBLE
+        type.visibility = View.VISIBLE
+        name.visibility = View.VISIBLE
+        time.visibility = View.VISIBLE
+        infoLayout.visibility = View.VISIBLE
+    }
+
+    private fun ViewHolder.hideFields(
+            hideName: Boolean = false,
+            hideTime: Boolean = false,
+            hideImage: Boolean = true) {
+
+        type.visibility = View.GONE
+        description.visibility = View.GONE
+        room.visibility = View.GONE
+        talkLanguage.visibility = View.GONE
+        name.visibility = if (hideName) View.GONE else View.VISIBLE
+        infoLayout.visibility = if (hideTime) View.GONE else View.VISIBLE
+        time.visibility = if (hideTime) View.GONE else View.VISIBLE
+        itemView.setOnClickListener(null)
+        if (hideImage) {
+            image.visibility = View.GONE
+        } else {
+            image.visibility = View.VISIBLE
+            image.setImageResource(R.drawable.mxt_topic_empty)
+        }
+    }
+
 }

--- a/app/src/main/java/org/mixitconf/adapter/UserListAdapter.kt
+++ b/app/src/main/java/org/mixitconf/adapter/UserListAdapter.kt
@@ -22,19 +22,21 @@ class UserListAdapter(private val items: List<User>, val context: Context) : Rec
         val speakerImage:ImageView = view.findViewById(R.id.speaker_image)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.fragment_speaker_item, parent, false)
-        return UserViewHolder(view)
-    }
+    override fun getItemCount(): Int = items.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder =
+            UserViewHolder(LayoutInflater
+                    .from(parent.context)
+                    .inflate(R.layout.fragment_speaker_item, parent, false))
 
     override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
         val user = items[position]
-
-        holder.speakerName.text = user.fullname()
-        holder.speakerBio.text = user.description[Language.FRENCH]
-        holder.speakerImage.setSpeakerImage(user)
-
-        holder.itemView.setOnClickListener({ _ -> (context as SpeakerFragment.OnSpeakerSelectedListener).onSpeakerSelected(user.login) })
+        holder.apply {
+            speakerName.text = user.fullname()
+            speakerBio.text = user.description[Language.FRENCH]
+            speakerImage.setSpeakerImage(user)
+            itemView.setOnClickListener { _ -> (context as SpeakerFragment.OnSpeakerSelectedListener).onSpeakerSelected(user.login) }
+        }
     }
 
     override fun onViewRecycled(holder: UserViewHolder?) {
@@ -45,11 +47,6 @@ class UserListAdapter(private val items: List<User>, val context: Context) : Rec
         }
 
     }
-
-    override fun getItemCount(): Int {
-        return items.size
-    }
-
 
 
 }

--- a/app/src/main/java/org/mixitconf/fragment/HomeFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/HomeFragment.kt
@@ -10,7 +10,6 @@ import org.mixitconf.R
 
 class HomeFragment : Fragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_home, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+        inflater.inflate(R.layout.fragment_home, container, false)
 }

--- a/app/src/main/java/org/mixitconf/fragment/SpeakerDetailFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/SpeakerDetailFragment.kt
@@ -20,9 +20,8 @@ import org.mixitconf.service.*
 
 class SpeakerDetailFragment : Fragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_speaker_detail, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_speaker_detail, container, false)
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)

--- a/app/src/main/java/org/mixitconf/fragment/SpeakerDetailFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/SpeakerDetailFragment.kt
@@ -27,9 +27,8 @@ class SpeakerDetailFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        if (arguments == null || context == null) {
-            throw IllegalStateException("SpeakerDetailFragment must be initialized with speaker id")
-        }
+        check(arguments != null && context != null)
+            { "SpeakerDetailFragment must be initialized with speaker id" }
 
         val speaker = UserReader.getInstance(context!!).findOne(arguments!!.getString(Utils.OBJECT_ID))
 

--- a/app/src/main/java/org/mixitconf/fragment/SpeakerFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/SpeakerFragment.kt
@@ -22,9 +22,8 @@ class SpeakerFragment : Fragment() {
         fun onSpeakerSelected(id: String):Int
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_datalist, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_datalist, container, false)
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/org/mixitconf/fragment/TalkDetailFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/TalkDetailFragment.kt
@@ -32,9 +32,8 @@ class TalkDetailFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        if (arguments == null || context == null) {
-            throw IllegalStateException("TalkDetailFragment must be initialized with talk id")
-        }
+        check(arguments != null && context != null)
+            { "TalkDetailFragment must be initialized with talk id" }
 
         val talk = TalkReader.getInstance(context!!).findOne(arguments!!.getString(Utils.OBJECT_ID))
         val calendarLoader = CalendarLoader(context!!, talk)
@@ -62,16 +61,15 @@ class TalkDetailFragment : Fragment() {
         navigation_calendar_add.setOnClickListener({ _ ->
             if (!context!!.hasPermission(Manifest.permission.WRITE_CALENDAR)) {
                 ActivityCompat.requestPermissions(activity!!, arrayOf(Manifest.permission.WRITE_CALENDAR, Manifest.permission.READ_CALENDAR), 0)
-            }
-            else{
+            } else {
                 val hasConcurrentEvent = calendarLoader.hasConcurrentEventInCalendar != null && calendarLoader.hasConcurrentEventInCalendar!!
 
                 // If we have an existing event in user calendar, we have to ask him if he wants to insert or not a new one
                 AlertDialog.Builder(context)
                         .setTitle(R.string.calendar_add)
-                        .setMessage(if(hasConcurrentEvent) R.string.calendar_question2 else R.string.calendar_question1)
+                        .setMessage(if (hasConcurrentEvent) R.string.calendar_question2 else R.string.calendar_question1)
                         .setPositiveButton(android.R.string.yes) { _, _ -> insertEventInCalendar(talk) }
-                        .setNegativeButton(android.R.string.no) { _, _ ->  }
+                        .setNegativeButton(android.R.string.no) { _, _ -> }
                         .show()
 
             }
@@ -83,7 +81,7 @@ class TalkDetailFragment : Fragment() {
         }
     }
 
-    private fun insertEventInCalendar(talk:Talk) = context!!.startActivity(Intent(Intent.ACTION_INSERT)
+    private fun insertEventInCalendar(talk: Talk) = context!!.startActivity(Intent(Intent.ACTION_INSERT)
             .setType("vnd.android.cursor.item/event")
             .setData(CalendarContract.Events.CONTENT_URI)
             .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, talk.start.time)

--- a/app/src/main/java/org/mixitconf/fragment/TalkDetailFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/TalkDetailFragment.kt
@@ -25,9 +25,8 @@ import org.mixitconf.service.*
 
 class TalkDetailFragment : Fragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_talk_detail, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_talk_detail, container, false)
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)

--- a/app/src/main/java/org/mixitconf/fragment/TalkFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/TalkFragment.kt
@@ -24,9 +24,8 @@ class TalkFragment : Fragment() {
         fun onTalkSelected(id: String):Int
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_datalist, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_datalist, container, false)
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/org/mixitconf/service/SpeakerService.kt
+++ b/app/src/main/java/org/mixitconf/service/SpeakerService.kt
@@ -11,10 +11,12 @@ class SpeakerService(val context: Context) {
 
     fun findSpeakers(): List<User> {
         val talks = TalkReader.getInstance(context).findAll()
-        return UserReader.getInstance(context).findByLogins(talks.flatMap { it.speakerIds }.toList())
+        return UserReader.getInstance(context).findByLogins(talks.flatMap { it.speakerIds })
     }
 
-    fun findSpeakerTalks(speaker: User): List<Talk> = TalkReader.getInstance(context).findAll().filter { it.speakerIds.contains(speaker.login) }.toList()
+    fun findSpeakerTalks(speaker: User): List<Talk> = TalkReader.getInstance(context)
+            .findAll()
+            .filter { it.speakerIds.contains(speaker.login) }
 
     companion object : SingletonHolder<SpeakerService, Context>(::SpeakerService)
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,8 +43,8 @@
     <string name="come_to_party">Venir à la soirée</string>
     <string name="appPermission">L\'application MiXiT peut s\'interfacer si tu le souhaites avec ton agenda pour ajouter les talks que tu veux voir. Bien évidemment ce n\'est pas obligatoire. Les données de ton agenda ne sont pas analysées. Nous vérifions simplement qu\'il n\'y ait pas d\'événement concurrent quand tu demandes l\'ajout d\'un talk pour éviter de polluer ton agenda.</string>
     <string name="en">EN</string>
-    <string name="calendar_add">Evénement caledrier</string>
-    <string name="calendar_question1">Veux tu ajouter cette session à ton celandrier ?</string>
-    <string name="calendar_question2">Tu as déjà un événement défini dans ton calendrier sur les mêmes plages horaires. Veux tu ajouter cette session à ton celandrier ?</string>
+    <string name="calendar_add">Evènement calendrier</string>
+    <string name="calendar_question1">Veux-tu ajouter cette session à ton calendrier ?</string>
+    <string name="calendar_question2">Tu as déjà un événement défini dans ton calendrier sur les mêmes plages horaires. Veux-tu ajouter cette session à ton calendrier ?</string>
 
 </resources>


### PR DESCRIPTION
French typo corrections.
Removing 2 redundant `toList()`
Expression body for simple (single line) body.
Coding convention for indentation. 
Using `check` instead of `if` + `throw` 