### PR TITLE
Preload talks and users

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,8 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "com.android.support:recyclerview-v7:$android_version"
     implementation "com.android.support:appcompat-v7:$android_version"
     implementation "com.android.support:design:$android_version"
@@ -59,6 +61,12 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+}
+
+kotlin {
+    experimental {
+        coroutines "enable"
+    }
 }
 
 

--- a/app/src/androidTest/java/org/mixitconf/repository/EventReaderTest.kt
+++ b/app/src/androidTest/java/org/mixitconf/repository/EventReaderTest.kt
@@ -20,7 +20,7 @@ class EventReaderTest {
     @Before
     fun init() {
         appContext = InstrumentationRegistry.getTargetContext()
-        reader = EventReader(appContext)
+        reader = EventReader.getInstance(appContext)
     }
 
     @Test

--- a/app/src/androidTest/java/org/mixitconf/repository/TalkReaderTest.kt
+++ b/app/src/androidTest/java/org/mixitconf/repository/TalkReaderTest.kt
@@ -21,7 +21,7 @@ class TalkReaderTest {
     @Before
     fun init() {
         appContext = InstrumentationRegistry.getTargetContext()
-        reader = TalkReader(appContext)
+        reader = TalkReader.getInstance(appContext)
     }
 
     @Test

--- a/app/src/androidTest/java/org/mixitconf/repository/UserReaderTest.kt
+++ b/app/src/androidTest/java/org/mixitconf/repository/UserReaderTest.kt
@@ -19,7 +19,7 @@ class UserReaderTest {
     @Before
     fun init() {
         appContext = InstrumentationRegistry.getTargetContext()
-        reader = UserReader(appContext)
+        reader = UserReader.getInstance(appContext)
     }
 
     @Test

--- a/app/src/main/java/org/mixitconf/MainActivity.kt
+++ b/app/src/main/java/org/mixitconf/MainActivity.kt
@@ -5,10 +5,14 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.design.widget.BottomNavigationView
 import android.support.v7.app.AppCompatActivity
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.coroutines.experimental.launch
 import org.mixitconf.fragment.*
+import org.mixitconf.repository.TalkReader
+import org.mixitconf.repository.UserReader
 import org.mixitconf.service.hasIntentPackage
 import org.mixitconf.service.openFragment
 import org.mixitconf.service.openFragmentDetail
@@ -20,6 +24,7 @@ open class MainActivity : AppCompatActivity(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.i("MainActivity","onCreate start")
         setContentView(R.layout.activity_main)
 
         // Initialize the top action bar to display Home button
@@ -29,6 +34,11 @@ open class MainActivity : AppCompatActivity(),
         }
 
         navigation.setOnNavigationItemSelectedListener(onNavigationItemSelectedListener)
+
+        launch {
+            TalkReader.getInstance(baseContext)
+            UserReader.getInstance(baseContext)
+        }
     }
 
     /**

--- a/app/src/main/java/org/mixitconf/repository/EventReader.kt
+++ b/app/src/main/java/org/mixitconf/repository/EventReader.kt
@@ -11,18 +11,14 @@ import org.mixitconf.service.SingletonHolder
 /**
  * Events are read from Json file
  */
-class EventReader(val context: Context) {
+class EventReader(val events: List<Event>) {
 
-    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    fun findAll(): List<Event> = events
+    fun findOne(id: String): Event = events.first { it.id == id }
 
-    private fun readFile(): List<Event>{
-        val jsonInputStream = context.resources.openRawResource(R.raw.events)
-        return objectMapper.readValue(jsonInputStream)
-    }
-
-    fun findAll(): List<Event> = readFile()
-
-    fun findOne(id: String): Event = readFile().first { it.id == id }
-
-    companion object : SingletonHolder<EventReader, Context>(::EventReader)
+    companion object : SingletonHolder<EventReader, Context>({
+            val jsonInputStream = it.resources.openRawResource(R.raw.events)
+            val events:List<Event> =  jacksonObjectMapper().readValue(jsonInputStream)
+            EventReader(events)
+    })
 }

--- a/app/src/main/java/org/mixitconf/repository/TalkReader.kt
+++ b/app/src/main/java/org/mixitconf/repository/TalkReader.kt
@@ -18,27 +18,17 @@ import java.util.*
 /**
  * Talk are read adjust Json file
  */
-class TalkReader(private val context: Context) {
+class TalkReader(val talks: List<Talk>, private val context: Context) {
 
-    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    companion object : SingletonHolder<TalkReader, Context>({
+        val jsonInputStream = it.resources.openRawResource(R.raw.talks_2018)
+        val talks:List<Talk> = jacksonObjectMapper().readValue(jsonInputStream)
+        TalkReader(talks, it)
+    })
 
-    companion object : SingletonHolder<TalkReader, Context>(::TalkReader) {
-        private val talks: MutableList<Talk> = mutableListOf()
-    }
+    fun findAll(): List<Talk> = talks
 
-    private fun readFile(): List<Talk> {
-        val jsonInputStream = context.resources.openRawResource(R.raw.talks_2018)
-        if (TalkReader.talks.isEmpty()) {
-            val talks: List<Talk> = objectMapper.readValue(jsonInputStream)
-            talks.forEach { TalkReader.talks.add(transformDate(it)) }
-        }
-        return TalkReader.talks
-
-    }
-
-    fun findAll(): List<Talk> = readFile()
-
-    fun findOne(id: String): Talk = readFile().first { it.id == id }
+    fun findOne(id: String): Talk = talks.first { it.id == id }
 
     fun findMarkers(): List<Talk> = listOf(
             createNonTalkMomentFirstDay(TalkFormat.DAY, 8, 0, R.string.event_day1),

--- a/app/src/main/java/org/mixitconf/repository/UserReader.kt
+++ b/app/src/main/java/org/mixitconf/repository/UserReader.kt
@@ -11,26 +11,17 @@ import org.mixitconf.service.SingletonHolder
 /**
  * Speakers are read from Json file
  */
-class UserReader(private val context: Context) {
+class UserReader(val users: List<User>) {
 
-    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    fun findAll(): List<User> = users
 
-    private fun readFile(): List<User>{
-        val jsonInputStream = context.resources.openRawResource(R.raw.users)
-        if(UserReader.users.isEmpty()){
-            val users: List<User> = objectMapper.readValue(jsonInputStream)
-            users.forEach { UserReader.users.add(it) }
-        }
-        return UserReader.users
-    }
+    fun findOne(login: String): User = users.first { it.login == login }
 
-    fun findAll(): List<User> = readFile()
+    fun findByLogins(logins: List<String>): List<User> = users.filter { logins.contains(it.login) }
 
-    fun findOne(login: String): User = readFile().first { it.login == login }
-
-    fun findByLogins(logins: List<String>): List<User> = readFile().filter { logins.contains(it.login) }
-
-    companion object : SingletonHolder<UserReader, Context>(::UserReader){
-        private val users:MutableList<User> = mutableListOf()
-    }
+    companion object : SingletonHolder<UserReader, Context>({
+        val json = it.resources.openRawResource(R.raw.users)
+        val users : List<User> = jacksonObjectMapper().readValue(json)
+        UserReader(users)
+    })
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.2.30'
+    ext.coroutines_version = '0.22.5'
     ext.android_version = '27.0.2'
     ext.jackson_version = '2.9.4'
     ext.txtmark_version = '0.13'


### PR DESCRIPTION
Touch the TalkReader and UserReader instance at the end of the app creation to read the json files and keep the users and talks in memory.

The call is done using coroutines. 
```
     launch {
            TalkReader.getInstance(baseContext)
            UserReader.getInstance(baseContext)
        }
```
It's an enhancement for issue https://github.com/mixitconf/mixit-android/issues/4