### PR TITLE
Store and restore the list position during onPause() and onResume().

### DIFF
--- a/app/src/main/java/org/mixitconf/fragment/SpeakerFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/SpeakerFragment.kt
@@ -1,6 +1,7 @@
 package org.mixitconf.fragment
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.support.v4.app.Fragment
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
@@ -15,6 +16,8 @@ import org.mixitconf.service.SpeakerService
 
 class SpeakerFragment : Fragment() {
 
+    private var listState:Parcelable? = null
+
     /**
      * Interface implemented by parent activity to display a speaker when user clicks on a speaker in the list
      */
@@ -24,6 +27,11 @@ class SpeakerFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_datalist, container, false)
+
+    override fun onPause() {
+        super.onPause()
+        listState = (dataList.layoutManager as LinearLayoutManager).onSaveInstanceState()
+    }
 
     override fun onResume() {
         super.onResume()
@@ -36,6 +44,7 @@ class SpeakerFragment : Fragment() {
             layoutManager = LinearLayoutManager(context)
             adapter = UserListAdapter(speakers, context)
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+            layoutManager.onRestoreInstanceState(listState)
         }
     }
 }

--- a/app/src/main/java/org/mixitconf/fragment/TalkFragment.kt
+++ b/app/src/main/java/org/mixitconf/fragment/TalkFragment.kt
@@ -1,6 +1,7 @@
 package org.mixitconf.fragment
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.support.v4.app.Fragment
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
@@ -17,6 +18,8 @@ import org.mixitconf.repository.TalkReader
 
 class TalkFragment : Fragment() {
 
+    private var listState: Parcelable? = null
+
     /**
      * Interface implemented by parent activity to display a talk when user clicks on a talk in the list
      */
@@ -26,6 +29,11 @@ class TalkFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_datalist, container, false)
+
+    override fun onPause() {
+        super.onPause()
+        listState = (dataList.layoutManager as LinearLayoutManager).onSaveInstanceState()
+    }
 
     override fun onResume() {
         super.onResume()
@@ -42,6 +50,7 @@ class TalkFragment : Fragment() {
             layoutManager = LinearLayoutManager(context)
             adapter = TalkListAdapter(talks.sortedWith(compareBy<Talk> { it.start }.thenBy { it.end }.thenBy { it.room }), context)
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+            layoutManager.onRestoreInstanceState(listState)
         }
     }
 }


### PR DESCRIPTION
This version store the position of the talk and speaker lists when clicking on an item. The user retrieves its previous position when using back button.

Fix #7

Should the scroll position be stored also when the user is using bottom navigation?